### PR TITLE
Add `wrapMeta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,52 @@ export const reducer: Reducer<State> = (state = initialState, action) => {
   </tr>
 
 </table>
+
+## Action meta
+
+You can use `wrapWithMeta` to generate an action creator that populates the
+`meta` property.
+
+```ts
+const deleteAccount = wrapWithMeta(
+  createAction(constants.deleteAccount),
+  () => ({
+    analytics: {
+      trackEvent: true,
+    },
+  })
+)
+
+// deleteAccount()
+// {
+//   type: 'deleteAccount',
+//   payload: undefined,
+//   meta: {
+//     analytics: {
+//       trackEvent: true,
+//     }
+//   }
+// }
+
+const removeUser = wrapWithMeta(
+  createAction<number>(constants.removeUser),
+  (payload) => ({
+    analytics: {
+      trackEvent: true,
+      id: payload,
+    },
+  })
+)
+
+// removeUser(1234)
+// {
+//   type: 'removeUser',
+//   payload: 1234,
+//   meta: {
+//     analytics: {
+//       trackEvent: true,
+//       id: 1234,
+//     }
+//   }
+// }
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export const DELETE = 'USERS_DELETE'
   </tr>
 </table>
 
-### Actions
+## Actions
 
 `createAction` takes one argument: the action constant. You get back a
 function that acts as any action creator.
@@ -84,13 +84,13 @@ export const setIncrementBy: ActionCreator<SetIncrementBy> = (n: number) => ({
   </tr>
 </table>
 
-### Reducers
+## Reducers
 
 `createReducer` builds a reducer for you. No more switch statements, you pass
 it an object.
 
-Use `tsGetReturnType` and `typeof` to get the type of a function's return
-value without having to know the interface beforehand.
+Use `ReturnType<T>` to get the type of a function's return value without
+having to know the interface beforehand.
 
 <table>
   <tr>
@@ -110,21 +110,18 @@ const initialState = {
 }
 
 export default createReducer(initialState, {
-  [actions.constants.increment]: (state, action) => {
-    return {
-      ...state,
-      currentNumber: state.currentNumber + state.incrementBy,
-    }
-  },
+  [actions.constants.increment]: (state, action) => ({
+    ...state,
+    currentNumber: state.currentNumber + state.incrementBy,
+  }),
 
-  [actions.constants.setIncrementBy]: (state, action) => {
-    const actionTyped = tsGetReturnType(actions.setIncrementBy, action)
-
-    return {
-      ...state,
-      incrementBy: actionTyped.payload,
-    }
-  },
+  [actions.constants.setIncrementBy]: (
+    state,
+    action: ReturnType<typeof actions.setIncrementBy>,
+  ) => ({
+    ...state,
+    incrementBy: actionTyped.payload,
+  }),
 })
 ```
 

--- a/src/createAction.test.ts
+++ b/src/createAction.test.ts
@@ -2,29 +2,19 @@ import * as assert from 'assert'
 
 import createAction from './createAction'
 
-interface Silly {
-  foo: number
-  bar: boolean
-}
-
-interface SillyMeta {
-  id: number
-}
-
 describe('createAction', () => {
   it('supports no arguments', () => {
     const action = createAction('action')
-    const actual = action(null)
+    const actual = action()
 
     assert.deepStrictEqual(actual, {
       type: 'action',
-      payload: null,
-      meta: undefined,
+      payload: undefined,
     })
   })
 
   it('supports payload as the first argument', () => {
-    const action = createAction<Silly>('action')
+    const action = createAction<{ foo: number; bar: boolean }>('action')
     const actual = action({ foo: 42, bar: true })
 
     assert.deepStrictEqual(actual, {
@@ -32,23 +22,6 @@ describe('createAction', () => {
       payload: {
         foo: 42,
         bar: true,
-      },
-      meta: undefined,
-    })
-  })
-
-  it('supports payload and metadata', () => {
-    const action = createAction<Silly, SillyMeta>('action')
-    const actual = action({ foo: 42, bar: true }, { id: 123 })
-
-    assert.deepStrictEqual(actual, {
-      type: 'action',
-      payload: {
-        foo: 42,
-        bar: true,
-      },
-      meta: {
-        id: 123,
       },
     })
   })

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -6,26 +6,15 @@ interface CreateAction {
   <TPayload>(type: string): (
     payload: TPayload,
   ) => { type: string; payload: TPayload }
-
-  <TPayload, TMeta>(type: string): (
-    payload: TPayload,
-    meta: TMeta,
-  ) => { type: string; payload: TPayload; meta: TMeta }
 }
 
 /**
- * Factory function that returns a redux action creator with two generic
- * arguments:
- * - the first is the payload
- * - the second is the meta
+ * Factory function that returns a redux action creator with one argument: the
+ * payload.
  */
-const createAction: CreateAction = (type: string) => (
-  payload?: any,
-  meta?: any,
-) => ({
+const createAction: CreateAction = (type: string) => (payload?: any) => ({
   type,
   payload,
-  meta,
 })
 
 export default createAction

--- a/src/wrapWithMeta.test.ts
+++ b/src/wrapWithMeta.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert'
+
+import createAction from './createAction'
+import wrapWithMeta from './wrapWithMeta'
+
+describe('wrapWithMeta', () => {
+  it('sets meta to payload if metaCreator not given', () => {
+    const action = createAction<number>('action')
+    const actionWithMeta = wrapWithMeta(action)
+    const actual = actionWithMeta(42)
+
+    assert.deepStrictEqual(actual, {
+      type: 'action',
+      payload: 42,
+      meta: 42,
+    })
+  })
+
+  it('uses metaCreator to build meta based off payload', () => {
+    const action = createAction<number>('action')
+    const actionWithMeta = wrapWithMeta(action, (payload) => ({
+      raw: payload,
+      string: payload.toString(),
+    }))
+    const actual = actionWithMeta(42)
+
+    assert.deepStrictEqual(actual, {
+      type: 'action',
+      payload: 42,
+      meta: {
+        raw: 42,
+        string: '42',
+      },
+    })
+  })
+})

--- a/src/wrapWithMeta.test.ts
+++ b/src/wrapWithMeta.test.ts
@@ -5,9 +5,8 @@ import wrapWithMeta from './wrapWithMeta'
 
 describe('wrapWithMeta', () => {
   it('sets meta to payload if metaCreator not given', () => {
-    const action = createAction<number>('action')
-    const actionWithMeta = wrapWithMeta(action)
-    const actual = actionWithMeta(42)
+    const action = wrapWithMeta(createAction<number>('action'))
+    const actual = action(42)
 
     assert.deepStrictEqual(actual, {
       type: 'action',
@@ -17,12 +16,11 @@ describe('wrapWithMeta', () => {
   })
 
   it('uses metaCreator to build meta based off payload', () => {
-    const action = createAction<number>('action')
-    const actionWithMeta = wrapWithMeta(action, (payload) => ({
+    const action = wrapWithMeta(createAction<number>('action'), (payload) => ({
       raw: payload,
       string: payload.toString(),
     }))
-    const actual = actionWithMeta(42)
+    const actual = action(42)
 
     assert.deepStrictEqual(actual, {
       type: 'action',
@@ -35,9 +33,8 @@ describe('wrapWithMeta', () => {
   })
 
   it('works when given metaCreator without payload', () => {
-    const action = createAction('action')
-    const actionWithMeta = wrapWithMeta(action, () => 'some meta')
-    const actual = actionWithMeta()
+    const action = wrapWithMeta(createAction('action'), () => 'some meta')
+    const actual = action()
 
     assert.deepStrictEqual(actual, {
       type: 'action',

--- a/src/wrapWithMeta.test.ts
+++ b/src/wrapWithMeta.test.ts
@@ -33,4 +33,16 @@ describe('wrapWithMeta', () => {
       },
     })
   })
+
+  it('works when given metaCreator without payload', () => {
+    const action = createAction('action')
+    const actionWithMeta = wrapWithMeta(action, () => 'some meta')
+    const actual = actionWithMeta()
+
+    assert.deepStrictEqual(actual, {
+      type: 'action',
+      payload: undefined,
+      meta: 'some meta',
+    })
+  })
 })

--- a/src/wrapWithMeta.ts
+++ b/src/wrapWithMeta.ts
@@ -1,0 +1,21 @@
+interface WrapWithMeta {
+  <TPayload>(
+    actionCreator: (payload: TPayload) => { type: string; payload: TPayload },
+  ): (payload: TPayload) => { type: string; payload: TPayload; meta: TPayload }
+
+  <TPayload, TMeta>(
+    actionCreator: (payload: TPayload) => { type: string; payload: TPayload },
+    metaBuilder: (payload: TPayload) => TMeta,
+  ): (payload: TPayload) => { type: string; payload: TPayload; meta: TMeta }
+}
+
+const wrapWithMeta: WrapWithMeta = (actionCreator: any, metaBuilder?: any) => (
+  payload: any,
+) => {
+  return {
+    ...actionCreator(payload),
+    meta: metaBuilder ? metaBuilder(payload) : payload,
+  }
+}
+
+export default wrapWithMeta

--- a/src/wrapWithMeta.ts
+++ b/src/wrapWithMeta.ts
@@ -3,6 +3,11 @@ interface WrapWithMeta {
     actionCreator: (payload: TPayload) => { type: string; payload: TPayload },
   ): (payload: TPayload) => { type: string; payload: TPayload; meta: TPayload }
 
+  <TMeta>(
+    actionCreator: () => { type: string },
+    metaBuilder: () => TMeta,
+  ): () => { type: string; meta: TMeta }
+
   <TPayload, TMeta>(
     actionCreator: (payload: TPayload) => { type: string; payload: TPayload },
     metaBuilder: (payload: TPayload) => TMeta,
@@ -10,7 +15,7 @@ interface WrapWithMeta {
 }
 
 const wrapWithMeta: WrapWithMeta = (actionCreator: any, metaBuilder?: any) => (
-  payload: any,
+  payload?: any,
 ) => {
   return {
     ...actionCreator(payload),


### PR DESCRIPTION
## Removes

- `meta` support from `createAction`, it was never really used and not very flexible.

## Adds

- `wrapMeta`. Can wrap any redux action, allowing you to generate the `meta` property based off of the incoming payload.